### PR TITLE
Add text-to-speech API route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ bun.lockb
 *.tsbuildinfo
 next-env.d.ts
 !/.env
+
+#vscode
+.vscode

--- a/src/app/api/text_to_speech/route.ts
+++ b/src/app/api/text_to_speech/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import OpenAI from "openai";
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+export const runtime = "edge";
+
+export async function POST(req: Request) {
+  const { message } = await req.json();
+  const response = await openai.audio.speech.create({
+    model: "tts-1",
+    voice: "alloy",
+    input: message
+  });
+  return new NextResponse(response.body)
+}


### PR DESCRIPTION
This commit adds a new API route for text-to-speech functionality. The route is implemented in the `src/app/api/text_to_speech/route.ts` file. It uses the OpenAI API to convert text to speech. The route accepts a POST request with a JSON payload containing the `message` to be converted. The response is an audio file generated by the OpenAI API.